### PR TITLE
Tidy up sortable <th> creation

### DIFF
--- a/grails-app/taglib/grails/plugins/remotepagination/RemotePaginationTagLib.groovy
+++ b/grails-app/taglib/grails/plugins/remotepagination/RemotePaginationTagLib.groovy
@@ -201,8 +201,7 @@ class RemotePaginationTagLib {
         attrs.each {k, v ->
             writer << "${k}=\"${v.encodeAsHTML()}\" "
         }
-        writer << """>${remoteLink(linkTagAttrs.clone()) { title } }
-                </th>"""
+        writer << """>${remoteLink(linkTagAttrs.clone()) { title } }</th>"""
     }
 
     /**


### PR DESCRIPTION
I have removed the newline and extra white space on line 205. It was causing formatting problems if the following css style was applied to the table header cell.

``` css
white-space:pre;
```
